### PR TITLE
Translate wiki into ZH_CN

### DIFF
--- a/README_ZH_CN.md
+++ b/README_ZH_CN.md
@@ -1,4 +1,4 @@
-# PalGuard v1.1066 (幻兽帕鲁服务器反作弊)
+# PalGuard v1.1199 (幻兽帕鲁服务器反作弊)
 
 #### [English](/README.md) / 简体中文
 

--- a/Wiki/Commands/README_ZH_CN.md
+++ b/Wiki/Commands/README_ZH_CN.md
@@ -29,7 +29,7 @@
 | `/giveitems <steamID> <物品ID>[:<数量>] ...` | `/giveitems 76567890987654321 LuxuryMedicines:42 Money:666 AssaultRifle_Default5` | 一次给玩家多个物品，并可以指定每个物品的数量，使用冒号分隔。 | X | X | X |
 | `/giveme <物品ID> [数量=1]` | `/giveme Lotus_hp_02 999` | 给自己一个物品，并可指定数量。 | X | X | |
 | `/delitem <steamID> <物品ID> [数量=1]` | `/delitem 76567890987654321 LuxuryMedicines all` | 从玩家身上删除物品，并可指定数量，默认删除一个物品。如果使用 `all`，将删除所有该物品。 | X | X | X |
-| `/delitems <steamID> <物品ID>[:<数量>] ...` | `/delitems 76567890987654321 LuxuryMedicines Milk:all Money:5000` | 一次删除多个物品，并可指定每个物品的数量。使用 `all` 替代 `1` 删除所有该物品。 | X | X | X |
+| `/delitems <steamID> <物品ID>[:<数量>] ...` | `/delitems 76567890987654321 LuxuryMedicines Milk:all Money:5000` | 一次删除多个物品，并可指定每个物品的数量，通过冒号分隔。使用 `all` 替代 `1` 删除所有该物品。 | X | X | X |
 | `/give_exp <steamID> <数量>` | `/give_exp 76567890987654321 400000` | 给玩家指定数量的经验值。 | X | X | X |
 | `/giveme_exp <数量>` | `/giveme_exp 400000` | 给自己指定数量的经验值。 | X | X | X |
 | `/whitelist_add <steamID>` | `/whitelist_add 76567890987654321` | 将 Steam ID 添加到白名单中。 | X | X | X |
@@ -37,6 +37,7 @@
 | `/whitelist_get` | `/whitelist_get` | 获取所有已添加到白名单中的玩家列表。 | X | X | X |
 | `/givepal <steamID> <PalId> <Level>` | `/givepal 76567890987654321 FengyunDeeper 55` | 给玩家一个帕鲁（如果玩家携带的帕鲁已满，将进入帕鲁终端）。 | X | X | X |
 | [/givepal_j](givepal_j_ZH_CN.md) | `/givepal_j <steamID> <PalJSON>` | 给玩家一个帕鲁，具有提供的 JSON 属性。（如果玩家携带的帕鲁已满，将进入帕鲁终端）。有关更多信息，请详见 [PalJSON](../Files/PalJSON_ZH_CN#json-file-template)。 | X | X | X |
+| [/deletepals](deletepals_ZH_CN.md) | `/deletepals <steamID> <PalFilter>` | 根据过滤器从玩家的帕鲁队伍和帕鲁终端中删除多个帕鲁。过滤器可以通过命令参数配置。 | X | X | X |
 | `/exportpals <steamID>` | `/exportpals 76567890987654321` | 导出玩家的所有帕鲁到 `Pal/Binaries/Win64/palguard/pals/` 文件夹。有关更多信息，请详见 [PalJSON](../Files/PalJSON_ZH_CN#json-file-template)。 | X | X | X |
 | `/jetragon` | `/jetragon` | 给你一个管理员级别的空涡龙（它超快...）。 | X | X | |
 | `/catwaifu` | `/catwaifu` | 给你一个管理员级别的暗巫猫，增加你的角色属性。 | X | X | |

--- a/Wiki/Commands/deletepals_ZH_CN.md
+++ b/Wiki/Commands/deletepals_ZH_CN.md
@@ -1,0 +1,67 @@
+### [<<<](README_ZH_CN.md) 命令
+
+#### [English](./deletepals.md) / 简体中文
+
+# /deletepals
+
+| |权限|
+|-|:---------:|
+|仅管理员|X|
+|聊天|X|
+|RCON|X|
+
+### 描述
+根据过滤器从玩家的帕鲁队伍和帕鲁终端中删除多个帕鲁。过滤器可以通过命令参数配置。被删除的帕鲁将创建一个 .json 文件，以便在使用不当时恢复帕鲁。目前需要手动查找文件，未来版本计划提供一个恢复帕鲁的命令。
+
+被删除的帕鲁可以在 `<palserver_root>/Pal/Binaries/Win64/palguard/pals/deleted/<SteamID>/` 中找到。
+
+### 语法
+
+```cmd
+/deletepals <steamID> <PalFilter>
+```
+
+### PalFilter
+该过滤器允许在一个命令行中使用多个关键字来删除符合条件的帕鲁。第一次使用时可能会比较复杂，所以请先在测试环境中尝试。
+
+以下是过滤器关键字及其说明：
+|关键字|值|符号|说明|
+|-|:---------:|:---------:|-|
+|ID|[PalID](../Data%20Lists/Pals.md) 或帕鲁列表|无|一个或多个 ID，使用 `,` 逗号分隔。不要用来忽略 ID 的过滤。|
+|Nick|字符串|无|过滤帕鲁的名称。如果不需要，请不要使用。|
+|Gender|`male` 或 `female`|无|按性别过滤。如果不需要过滤性别，请不要使用。|
+|Level|数字|`<`, `>`, `<=`, `>=`, `=`, `!=`|按等级过滤。使用符号指定。例如，`Level>=35` 会包括等级为 35 及以上的帕鲁。|
+|Rank|数字|`<`, `>`, `<=`, `>=`, `=`, `!=`|按排名过滤。使用符号指定。例如，`Rank>1` 会包括排名高于 1 的帕鲁。排名是根据相同帕鲁的综合排名。|
+|Lucky|`true` 或 `false`|无|过滤是否为稀有（闪亮）伙伴。|
+|Passives|[PassiveSkill](../Data%20Lists/PassiveSkills_ZH_CN.md) 或被动技能列表|无|一个或多个 ID，使用 `,` 逗号分隔。不要用来忽略技能的过滤。|
+|Limit|数字|无|限制过滤结果的数量。例如，`Limit 5` 会使过滤器只找到 5 个帕鲁，即使可以找到更多。|
+
+### 用法  
+```cmd
+/deletepals 76567890987654321 ID Serpent, PinkLizard Level>10 Gender male Limit 3
+```
+这将删除最多 3 个等级高于 10 的帕鲁（因此等级为 10 或以下的帕鲁不会被删除），性别为男性，且帕鲁为滑水蛇或博爱蜥。
+<br>
+<br>
+<br>
+
+```cmd
+/deletepals 76567890987654321 ID Anubis Rank >= 3
+```
+这将删除所有排名为 3 或以上的阿努比斯。
+<br>
+<br>
+<br>
+
+```cmd
+/deletepals 76561198033277828 Passives CraftSpeed_up1,CraftSpeed_up2,Rare,PAL_CorporateSlave
+```
+这将删除拥有所有 4 个被动技能的帕鲁。
+
+被动技能如下：
+- CraftSpeed_up1 = Serious（认真）<br>
+- CraftSpeed_up2 = Artisan（工匠精神）<br>
+- Rare = Lucky（稀有）<br>
+- PAL_CorporateSlave = Work Slave（社畜）<br>
+
+因此，需要拥有这 4 个被动技能，如果只拥有 3 个，它将被忽略。

--- a/Wiki/Data Lists/README_ZH_CN.md
+++ b/Wiki/Data Lists/README_ZH_CN.md
@@ -9,5 +9,9 @@
 ## 列表
 
 #### 与帕鲁相关的列表：
-* [帕鲁技能](EPalWazaIDs_ZH_CN.md)
+* [帕鲁技能（未翻译）](EPalWazaIDs_ZH_CN.md)
 * [被动技能](PassiveSkills_ZH_CN.md)
+* [帕鲁（未翻译）](Pals.md)
+
+#### 与物品相关的列表：
+* [物品（未翻译）](Items.md)

--- a/Wiki/Files/PalGuard Config_ZH_CN.md
+++ b/Wiki/Files/PalGuard Config_ZH_CN.md
@@ -1,0 +1,42 @@
+### [<<<](README_ZH_CN.md) 文件类型
+
+#### [English](./PalGuard%20Config.md) / 简体中文
+
+# PalGuard.json
+
+以下是每个配置项的的说明:
+| 配置项 | 值 | 说明 |
+|--------|-----|------|
+| `RCONbase64` | true, false | 设置为`true`可以在RCON中使用Base64编码 优点：适用于unicode字符（中文/韩语/俄语/等）缺点： 您只能使用支持编码/解码 base64的RCON客户端。 |
+| `adminAutoLogin` | true, false | 如果您的IP与管理员白名单匹配，则自动授予您管理员权限。 |
+| `adminIPs` | `["127.0.0.1", "..."]` | 允许使用管理员指令的白名单IP地址列表。 |
+| `allowAdminCheats` | true, false | 允许管理员进行作弊行为而不会受到惩罚。 |
+| `announceConnections` | true, false | 当玩家加入/离开服务器时广播消息。 |
+| `announcePunishments` | true, false | 当玩家被反作弊系统踢出或封禁时广播消息。 |
+| `bannedChatWords` | `["word1", "word2", "..."]` | 用于过滤RMT（即现实金钱交易，用现实货币交易虚拟物品的行为）广告的单词列表。包含这些词的消息将被阻止。 |
+| `bannedIPs` | `["127.0.0.1", "..."]` | 被封禁的IP地址列表。 |
+| `bannedMessage` | "You are banned." | 允许您自定义玩家在 IP 被禁止时尝试加入您的服务器时看到的消息（支持中文）。 |
+| `bannedNames` | `["anquan666", "Goldberg"]` | 一些基本的盗版保护（封禁的玩家昵称）。 |
+| `blockTowerBossCapture` | true, false | 启用/禁用捕捉高塔boss。 |
+| `chatBypassWait` | true, false | 可以让你在发送聊天信息时不再有1分钟的冷却时间。 |
+| `disableButchering` | true, false | 禁用屠宰功能，以防止无限屠宰的物品复制漏洞。 |
+| `disableIllegalItemProtection` | true, false | 禁用对调试/抢劫球体（某些模组将其作为可制作物品添加到游戏中）的保护。 |
+| `disableRenaming` | true, false | 禁用玩家重命名功能（他们仍然可以改宠物的名字）。 |
+| `doActionUponIllegalPalStats` | true, false | 检测到作弊时执行操作（设置为 false，则在检测到作弊时不会执行踢出或封禁等操作，需要人工判断）。 |
+| `isChineseCmd` | true, false | 如果你希望显示中文字符并使用默认的windows命令行，请将此设置为`true`。在较新的Windows版本中可以忽略。 |
+| `logChat` | true, false | 将所有聊天消息记录到日志。 |
+| `logNetworking` | true, false | 将玩家发送给服务器的几乎所有网络数据记录到日志。 |
+| `logRCON` | true, false | 将所有RCON命令记录到日志。 |
+| `palStatsMaxRank` | 任何正数（包括0） | 设置强化帕鲁的最大等级限制。设置为0任何玩家都无法强化帕鲁。任何大于0的数值将设置新的限制，默认为10。如果设置为-1，将检测服务器的最大帕鲁强化等级，并相应地更新此值。 |
+| `pveMaxToPalBanThreshold` | 任何正数 | 尝试对高于此数值的帕鲁造成伤害时，将标记为作弊者。 |
+| `pvpMaxToPalDamage` | 任何正数 | 如果启用PVP（bEnablePlayerToPlayerDamage），玩家对帕鲁造成的最大伤害超过此数值，将会被限制为该数值。此选项适用于未经任何伤害减免的伤害。 |
+| `pvpMaxToBuildingDamage` | 任何正数 | 同`pvpMaxToPalDamage`，但针对建筑物。此选项适用于未经任何伤害减免的伤害。 |
+| `shouldBanCheaters` | true, false | 允许反作弊系统自动封禁作弊者。 |
+| `shouldIPBanCheaters` | true, false | 允许反作弊系统自动封禁作弊者IP。 |
+| `shouldKickCheaters` | true, false | 允许反作弊系统自动踢出作弊者。 |
+| `shouldWarnCheaters` | true, false | 允许反作弊系统在聊天中警告作弊者。 |
+| `shouldWarnCheatersReason` | true, false | 提供作弊者被警告的原因。 |
+| `steamidProtection` | true, false | 防止相同的SteamID在玩家已经登录时再次加入服务器。 |
+| `useAdminWhitelist` | true, false | 启用/禁用管理员IP白名单系统（仅有adminIPs中的IP地址的玩家可以通过/adminpassword指令获得管理员权限）。 |
+| `useWhitelist` | true, false | 启用/禁用SteamID白名单（仅有在SteamID白名单列表中的玩家可以进入服务器）。 |
+| `whitelistMessage` | "You are not whitelisted." | 自定义未被列入白名单时显示的消息（支持中文）。 |

--- a/Wiki/Files/README_ZH_CN.md
+++ b/Wiki/Files/README_ZH_CN.md
@@ -3,5 +3,5 @@
 #### [English](./README.md) / 简体中文
 
 # 文件类型
-
+- [PalGuard.json](./PalGuard%20Config_ZH_CN.md) (反作弊配置文件)
 - [PalJSON](PalJSON_ZH_CN.md)

--- a/Wiki/README_ZH_CN.md
+++ b/Wiki/README_ZH_CN.md
@@ -7,8 +7,42 @@
 - [命令](./Commands/README_ZH_CN.md)
 - [文件类型](./Files/README_ZH_CN.md)
 - [数据列表](./Data%20Lists/README_ZH_CN.md)
-  
+- [常见问题解答](#faq)
+  - [我不小心封禁了自己/别人。如何解除封禁？](#我不小心封禁了自己别人如何解除封禁)
+  - [我无法以管理员身份登录，显示管理员命令被白名单保护。](#我无法以管理员身份登录显示管理员命令被白名单保护)
+  - [我的服务器在启动时崩溃。](#我的服务器在启动时崩溃)
+  - [我在服务器控制台中无法正确看到某些符号。](#我在服务器控制台中无法正确看到某些符号)
+  - [如何报告崩溃？](#如何报告崩溃)
+
 </details>
 
 ## 前言
-Wiki 目前正在建设中，因此内容不完整。我们非常欢迎您提供贡献或指出错误，这样 Wiki 将会慢慢且稳步地完善。
+此Wiki正在建设中，因此内容不完整。如果您能提供贡献或指出错误，将有助于Wiki逐步完善。
+
+## 常见问题解答
+### 我不小心封禁了自己/别人。如何解除封禁？
+如果是封禁了他们的IP，您需要暂时编辑`palguard.json`文件，并重新加载配置或重启服务器。如果是封禁了他们的账户，您需要从`Pal\Saved\SaveGames\banlist.txt`中删除他们的SteamID，并等待几分钟或在此之后重启服务器。
+
+---
+
+### 我无法以管理员身份登录，显示管理员命令被白名单保护。
+确保您已将您的IP地址添加到`palguard.json`文件中，如图所示。或者，您可以将`useAdminWhitelist`设置为`false`，但这不推荐，因为已知作弊者有某种漏洞能够获取管理员密码。
+
+![AdminWhitelist](/.github/images/AdminWhitelist.png)
+
+---
+
+### 我的服务器在启动时崩溃。
+请确保`palguard.json`文件没有配置错误，尝试删除该文件并重新启动服务器。如果仍然无法解决问题，且这是您第一次使用PalGuard，建议安装[VC++ redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170)。
+
+---
+
+### 我在服务器控制台中无法正确看到某些符号。
+请使用Windows Terminal（或任何支持Unicode的替代终端）代替默认的Windows控制台。
+
+---
+
+### 如何报告崩溃？
+将`Pal\Saved\Crashes\*随机数字*\CrashContext.runtime-xml`文件 + 使用的PalGuard版本 + `Pal\Binaries\Win64\logs`文件夹中的日志发送至[discord](https://discord.com/invite/jcvKpkUmXS)的bug-reports频道。
+
+---


### PR DESCRIPTION
Only three documents remained, EPalWazaIDs.md, Pals.md, and Items.md, which had not been translated